### PR TITLE
Remove needless space between name and colon.

### DIFF
--- a/Twitter/usptomo-tweet
+++ b/Twitter/usptomo-tweet
@@ -87,7 +87,7 @@ sed 's/,$//' 	> $tmp-header-str
 
 #########################################
 #出力!
-curl -H "Authorization : OAuth $(cat $tmp-header-str)" \
+curl -H "Authorization: OAuth $(cat $tmp-header-str)" \
      -d "status=$TW" "$URL"
 
 rm -f $tmp-*


### PR DESCRIPTION
With the space I got a response "400 Bad Request". To post a new tweet successfully I had to remove it.

It can be a version-specific issue of curl. My environment is:

```
$ curl --version
curl 7.35.0 (arm-unknown-linux-gnueabihf) libcurl/7.35.0 OpenSSL/1.0.1f zlib/1.2.8 libidn/1.28 librtmp/2.3
Protocols: dict file ftp ftps gopher http https imap imaps ldap ldaps pop3 pop3s rtmp rtsp smtp smtps telnet tftp
Features: AsynchDNS GSS-Negotiate IDN IPv6 Largefile NTLM NTLM_WB SSL libz TLS-SRP
$ lsb_release -a
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 14.04.3 LTS
Release:        14.04
Codename:       trusty
```

Tested on Lubuntu.
